### PR TITLE
Add save_raw functionality to route_cyclestreet

### DIFF
--- a/R/crs-funs.R
+++ b/R/crs-funs.R
@@ -71,11 +71,15 @@ reproject = function(shp, crs = crs_select_aeq(shp)){
 #' raster::crs(rbuf)
 #' plot(routes_fast, col = "green", add = TRUE)
 gprojected = function(shp, fun, crs = crs_select_aeq(shp), ...){
-  shp_projected = reproject(shp, crs = crs)
-  message(paste0("Running function on a temporary projected version of the Spatial object using the CRS: ", crs))
-  res = fun(shp_projected, ...)
-  if(is(res, "Spatial"))
-    res = spTransform(res, CRS("+init=epsg:4326"))
+  if(is.projected(shp)){
+    res = fun(shp, ...)
+  } else {
+    shp_projected = reproject(shp, crs = crs)
+    message(paste0("Running function on a temporary projected version of the Spatial object using the CRS: ", crs))
+    res = fun(shp_projected, ...)
+    if(is(res, "Spatial"))
+      res = spTransform(res, CRS("+init=epsg:4326"))
+  }
   res
 }
 

--- a/R/od-funs.R
+++ b/R/od-funs.R
@@ -341,3 +341,6 @@ points2line = function(p){
   raster::crs(l) = p_proj
   l
 }
+geo_dist = function(p1, p2){
+  gprojected(points2line(p1, p2), fun = rgeos::gDistance)
+}

--- a/R/radiate.R
+++ b/R/radiate.R
@@ -37,12 +37,14 @@ od_radiation <- function(p, pop_var = "population", proportion = 1){
       if(i == j) next()
       m <- p[[pop_var]][i]
       n <- p[[pop_var]][j]
+      sel_flow = which(l$O == p@data[i,1] & l$D == p@data[j,1])
       # create circle the radius of which is the distance between i and j centered on i
-      s_circle <- stplanr::buff_geo(p[i,], width = geosphere::distHaversine(p[i,], p[j,]))
+      radius = gprojected(shp = l[sel_flow,], fun = rgeos::gLength)
+      s_circle <- buff_geo(shp = p[i,], width = radius)
       ps <- p[-c(i, j),][s_circle,]
       s <- sum(ps[[pop_var]])
-      l$flow[l$O == p@data[i,1] & l$D == p@data[j,1]] <-
-        p$population[i] * proportion * ((m * n) / ((m + s) * (m + n + s)))
+      l$flow[sel_flow] <-
+        p[[pop_var]][i] * proportion * ((m * n) / ((m + s) * (m + n + s)))
     }
   }
   l

--- a/R/routes.R
+++ b/R/routes.R
@@ -57,7 +57,8 @@
 #' @param base_url The base url from which to construct API requests
 #' (with default set to main server)
 #' @param reporterrors Boolean value (TRUE/FALSE) indicating if cyclestreets
-#' should report errors.
+#' should report errors (FALSE by default).
+#' @param save_raw Boolean value which returns raw list from the json if TRUE (FALSE by default).
 #' @export
 #' @seealso line2route
 #' @examples

--- a/R/routes.R
+++ b/R/routes.R
@@ -63,6 +63,17 @@
 #' @examples
 #'
 #' \dontrun{
+#' # Example from
+#' from = c(0.117950, 52.205302); to = c(0.131402, 52.221046)
+#' json_output = route_cyclestreet(from = from, to = to, plan = "quietest", save_raw = TRUE)
+#' str(json_output) # what does cyclestreets give you?
+#' names(json_output$marker$`@attributes`)
+#' json_output$marker$`@attributes`$start[1] # starting point
+#' json_output$marker$`@attributes`$finish[1] # end point
+#' json_output$marker$`@attributes`$speed[1] # assumed speed (km/hr)
+#' json_output$marker$`@attributes`$busynance # busyness of each section
+#' json_output$marker$`@attributes`$elevations # list of elevations
+#' # jsonlite::toJSON(json_output, pretty = TRUE) # complete json output (long!)
 #' # Plan the 'fastest' route between two points in Manchester
 #' rf_mcr <- route_cyclestreet(from = "M3 4EE", to = "M1 4BT", plan = "fastest")
 #' rf_mcr@data
@@ -78,6 +89,7 @@
 #' woodys_route = route_cyclestreet(from = "Stokesley", plan = "fastest", to = "Leeds")
 #' # Plan a route between two lat/lon pairs in the UK
 #' route_cyclestreet(c(-2, 52), c(-1, 53), "fastest")
+#' raw_output = route_cyclestreet(0.117950,52.205302,City+Centre|0.131402,52.221046,Mulberry+Close|0.147324,52.199650)
 #' }
 route_cyclestreet <- function(from, to, plan = "fastest", silent = TRUE, pat = NULL,
                               base_url = "http://www.cyclestreets.net", reporterrors = FALSE,

--- a/R/routes.R
+++ b/R/routes.R
@@ -90,7 +90,6 @@
 #' woodys_route = route_cyclestreet(from = "Stokesley", plan = "fastest", to = "Leeds")
 #' # Plan a route between two lat/lon pairs in the UK
 #' route_cyclestreet(c(-2, 52), c(-1, 53), "fastest")
-#' raw_output = route_cyclestreet(0.117950,52.205302,City+Centre|0.131402,52.221046,Mulberry+Close|0.147324,52.199650)
 #' }
 route_cyclestreet <- function(from, to, plan = "fastest", silent = TRUE, pat = NULL,
                               base_url = "http://www.cyclestreets.net", reporterrors = FALSE,

--- a/R/toptail.R
+++ b/R/toptail.R
@@ -80,17 +80,16 @@ toptail <- function(l, toptail_dist, ...){
 #' buff <- buff_geo(routes_fast, width = 100)
 #' plot(buff)
 #' plot(routes_fast, add = TRUE)
+#' # Test it works the same on projected data
+#' shp <- spTransform(routes_fast, CRS("+init=epsg:27700"))
+#' buff2 = buff_geo(shp, 50) # test if it works the same on projected data
+#' plot(buff2)
+#' plot(routes_fast, add = T) # note they do not show
+#' buff3 = spTransform(buff2, CRS("+init=epsg:4326"))
+#' plot(buff)
+#' plot(buff3, add = T, col = "black")
 buff_geo <- function(shp, width, ..., silent = TRUE){
-  old_proj <- CRS(proj4string(shp))
-  new_proj <- crs_select_aeq(shp)
-  if(silent == FALSE){
-    message(paste0("The new Azimuthal equidistant projection",
-    "used to create the buffer was ", new_proj))
-    message(paste0("The original projection was ", old_proj))
-  }
-  shp <- sp::spTransform(shp, new_proj)
-  buff <- rgeos::gBuffer(shp, width = width, ...)
-  sp::spTransform(buff, old_proj)
+  gprojected(shp = shp, fun = rgeos::gBuffer, width = width)
 }
 
 #' Clip the first and last n metres of SpatialLines

--- a/man/buff_geo.Rd
+++ b/man/buff_geo.Rd
@@ -29,5 +29,13 @@ sp::proj4string(routes_fast) <- CRS("+init=epsg:4326")
 buff <- buff_geo(routes_fast, width = 100)
 plot(buff)
 plot(routes_fast, add = TRUE)
+# Test it works the same on projected data
+shp <- spTransform(routes_fast, CRS("+init=epsg:27700"))
+buff2 = buff_geo(shp, 50) # test if it works the same on projected data
+plot(buff2)
+plot(routes_fast, add = T) # note they do not show
+buff3 = spTransform(buff2, CRS("+init=epsg:4326"))
+plot(buff)
+plot(buff3, add = T, col = "black")
 }
 

--- a/man/route_cyclestreet.Rd
+++ b/man/route_cyclestreet.Rd
@@ -5,7 +5,8 @@
 \title{Plan a single route with CycleStreets.net}
 \usage{
 route_cyclestreet(from, to, plan = "fastest", silent = TRUE, pat = NULL,
-  base_url = "http://www.cyclestreets.net", reporterrors = FALSE)
+  base_url = "http://www.cyclestreets.net", reporterrors = FALSE,
+  save_raw = "FALSE")
 }
 \arguments{
 \item{from}{Text string or coordinates (a numeric vector of
@@ -27,7 +28,9 @@ this is usually aquired automatically through a helper, api_pat().}
 (with default set to main server)}
 
 \item{reporterrors}{Boolean value (TRUE/FALSE) indicating if cyclestreets
-should report errors.}
+should report errors (FALSE by default).}
+
+\item{save_raw}{Boolean value which returns raw list from the json if TRUE (FALSE by default).}
 }
 \description{
 Provides an R interface to the CycleStreets.net cycle planning API,
@@ -71,6 +74,17 @@ Read more about the .Renviron here: \code{?.Renviron}
 \examples{
 
 \dontrun{
+# Example from
+from = c(0.117950, 52.205302); to = c(0.131402, 52.221046)
+json_output = route_cyclestreet(from = from, to = to, plan = "quietest", save_raw = TRUE)
+str(json_output) # what does cyclestreets give you?
+names(json_output$marker$`@attributes`)
+json_output$marker$`@attributes`$start[1] # starting point
+json_output$marker$`@attributes`$finish[1] # end point
+json_output$marker$`@attributes`$speed[1] # assumed speed (km/hr)
+json_output$marker$`@attributes`$busynance # busyness of each section
+json_output$marker$`@attributes`$elevations # list of elevations
+# jsonlite::toJSON(json_output, pretty = TRUE) # complete json output (long!)
 # Plan the 'fastest' route between two points in Manchester
 rf_mcr <- route_cyclestreet(from = "M3 4EE", to = "M1 4BT", plan = "fastest")
 rf_mcr@data
@@ -86,6 +100,7 @@ rb_pa <- route_cyclestreet("Pedaller's Arms, Leeds", "University of Leeds", "bal
 woodys_route = route_cyclestreet(from = "Stokesley", plan = "fastest", to = "Leeds")
 # Plan a route between two lat/lon pairs in the UK
 route_cyclestreet(c(-2, 52), c(-1, 53), "fastest")
+raw_output = route_cyclestreet(0.117950,52.205302,City+Centre|0.131402,52.221046,Mulberry+Close|0.147324,52.199650)
 }
 }
 \seealso{

--- a/man/route_cyclestreet.Rd
+++ b/man/route_cyclestreet.Rd
@@ -100,7 +100,6 @@ rb_pa <- route_cyclestreet("Pedaller's Arms, Leeds", "University of Leeds", "bal
 woodys_route = route_cyclestreet(from = "Stokesley", plan = "fastest", to = "Leeds")
 # Plan a route between two lat/lon pairs in the UK
 route_cyclestreet(c(-2, 52), c(-1, 53), "fastest")
-raw_output = route_cyclestreet(0.117950,52.205302,City+Centre|0.131402,52.221046,Mulberry+Close|0.147324,52.199650)
 }
 }
 \seealso{

--- a/tests/testthat/test-calc_catchment.R
+++ b/tests/testthat/test-calc_catchment.R
@@ -17,4 +17,6 @@ test_that(
       dissolve = TRUE
     )
     expect_is(t1, "SpatialPolygonsDataFrame")
+    files_to_remove = list.files(pattern = "smallsa|testcycleway")
+    file.remove(files_to_remove)  # tidy up
   })

--- a/tests/testthat/test-route_cyclestreet.R
+++ b/tests/testthat/test-route_cyclestreet.R
@@ -4,7 +4,7 @@ test_that(
   desc = "route_cyclestreet generates a SpatialLinesDataFrame output",
   code = {
     if(!Sys.getenv("CYCLESTREET") == ""){ # only run test if user has set an api key
-      rf <- route_cyclestreet("leeds", "bradford", "fastest", base_url = "http://pct.cyclestreets.net")
+      rf <- route_cyclestreet("leeds", "bradford", "fastest")
       expect_is(rf, "SpatialLinesDataFrame")
     }
   })


### PR DESCRIPTION
I think we should additionally do this for the other routing functions so people can go back to the raw json files spat out by these things. Will put in a separate issue for splitting out the code used to interpret the json objects and look into the implications of this for the `line2route()` wrapper function.

Comments welcome.