### PR TITLE
Small change to sum_network_routes function

### DIFF
--- a/R/SpatialLinesNetwork.R
+++ b/R/SpatialLinesNetwork.R
@@ -85,6 +85,11 @@ SpatialLinesNetwork = function(sl, uselonglat = FALSE) {
 #' for the geographic (SpatialLines) representation or "graph" for the graph
 #' representation.
 #' @param ... Arguments to pass to relevant plot function.
+#' @examples
+#' data(routes_fast)
+#' rnet <- overline(sldf = routes_fast, attrib = "length")
+#' SLN <- SpatialLinesNetwork(rnet)
+#' plot(SLN)
 #' @export
 setMethod("plot", signature = c(x="SpatialLinesNetwork"),
           definition = function(x, component = "sl", ...){
@@ -115,6 +120,13 @@ setMethod("plot", signature = c(x="SpatialLinesNetwork"),
 #' passed to the replacement function. If the dataframe contains multiple
 #' columns, the column with the same name as \code{varname} is used,
 #' otherwise the first column is used.
+#' @examples
+#' data(routes_fast)
+#' rnet <- overline(sldf = routes_fast, attrib = "length")
+#' SLN <- SpatialLinesNetwork(rnet)
+#' weightfield(SLN) <- 'length'
+#' weightfield(SLN, 'randomnum') <- sample(1:10, size = nrow(SLN@sl), replace = TRUE)
+#'
 #' @name weightfield
 NULL
 
@@ -172,7 +184,12 @@ setReplaceMethod("weightfield", signature(x = "SpatialLinesNetwork", varname = "
 #' Print a summary of a SpatialLinesNetwork
 #'
 #' @param object The SpatialLinesNetwork
-#' @param ... Arguments to pass to relevant plot function.
+#' @param ... Arguments to pass to relevant summary function.
+#' @examples
+#' data(routes_fast)
+#' rnet <- overline(sldf = routes_fast, attrib = "length")
+#' SLN <- SpatialLinesNetwork(rnet)
+#' summary(SLN)
 #' @export
 setMethod("summary", signature = c(object="SpatialLinesNetwork"),
         definition = function(object, ...){
@@ -202,6 +219,11 @@ setMethod("summary", signature = c(object="SpatialLinesNetwork"),
 #' @return An integer value with the ID of the node closest to \code{(x,y)}
 #' with a value of \code{NA} the closest node is further than \code{maxdist}
 #' from \code{(x,y)}. If \code{x} is a vector, returns a vector of Node IDs.
+#' @examples
+#' data(routes_fast)
+#' rnet <- overline(sldf = routes_fast, attrib = "length")
+#' SLN <- SpatialLinesNetwork(rnet)
+#' find_network_nodes(SLN, -1.516734, 53.828)
 #' @export
 find_network_nodes <- function(sln, x, y = NULL, maxdist = 1000) {
   if(!is(sln, "SpatialLinesNetwork")) {
@@ -235,28 +257,6 @@ find_network_nodes <- function(sln, x, y = NULL, maxdist = 1000) {
   longlat <- ifelse(is.projected(sln@sl) == TRUE, FALSE, TRUE)
   maxdist <- ifelse(longlat == TRUE, maxdist/1000, maxdist)
 
-  # if (length(x) == 1) {
-  #   # nodedists = geosphere::distHaversine(data.frame(x=sln@g$x, y=sln@g$y),c(x,y))
-  #   nodedists = sp::spDists(x = as.matrix(data.frame(x=sln@g$x, y=sln@g$y)),
-  #                           y = matrix(c(x,y),ncol=2),
-  #                           longlat = longlat)
-  #   nodeid = which(nodedists == min(nodedists))[1]
-  #   mindist = nodedists[nodeid]
-  #   nodeid = ifelse(mindist <= maxdist,nodeid,NA)
-  # }
-  # else {
-    # nodeid = c()
-    # mindist = c()
-    # i <- 1
-    # while (i <= length(x)) {
-    #   # nodedists = geosphere::distHaversine(data.frame(x=sln@g$x, y=sln@g$y),c(x[i],y[i]))
-    #   nodedists = sp::spDists(x = as.matrix(data.frame(x=sln@g$x, y=sln@g$y)),
-    #                           y = matrix(c(x[i],y[i]),ncol=2),
-    #                           longlat = longlat)
-    #   nodeid[i] = which(nodedists == min(nodedists))[1]
-    #   mindist[i] = nodedists[nodeid[i]]
-    #   i <- i + 1
-    # }
     distlist <- lapply(1:length(x), function(i, gxy){
       sp::spDists(x = gxy,
                   y = matrix(c(x[i],y[i]),ncol=2),
@@ -267,9 +267,6 @@ find_network_nodes <- function(sln, x, y = NULL, maxdist = 1000) {
                        ifelse(min(x) > maxdist, NA, which(x == min(x))[1])
                      },
                      maxdist)
-
-    # nodeid <- ifelse(mindist <= maxdist, nodeid, NA)
-  # }
 
 
   return(nodeid)
@@ -292,6 +289,16 @@ find_network_nodes <- function(sln, x, y = NULL, maxdist = 1000) {
 #' and ends should be calculated. If TRUE then every start Node ID will be routed
 #' to every end Node ID. This is faster than passing every combination to start
 #' and end. Default is FALSE.
+#'
+#' @examples
+#' data(routes_fast)
+#' rnet <- overline(sldf = routes_fast, attrib = "length")
+#' SLN <- SpatialLinesNetwork(rnet)
+#' weightfield(SLN) # field used to determine shortest path
+#' shortpath <- sum_network_routes(SLN, 1, 50, sumvars = "length")
+#' plot(shortpath, col = "red", lwd = 4)
+#' plot(SLN, add = TRUE)
+#'
 #' @export
 sum_network_routes <- function(sln, start, end, sumvars, combinations = FALSE) {
 

--- a/man/find_network_nodes.Rd
+++ b/man/find_network_nodes.Rd
@@ -36,4 +36,10 @@ Find graph node ID of closest node to given coordinates
 Finds the node ID of the closest point to a single coordinate pair (or a
 set of coordinates) from a SpatialLinesNetwork.
 }
+\examples{
+data(routes_fast)
+rnet <- overline(sldf = routes_fast, attrib = "length")
+SLN <- SpatialLinesNetwork(rnet)
+find_network_nodes(SLN, -1.516734, 53.828)
+}
 

--- a/man/plot-SpatialLinesNetwork-ANY-method.Rd
+++ b/man/plot-SpatialLinesNetwork-ANY-method.Rd
@@ -19,4 +19,10 @@ representation.}
 \description{
 Plot a SpatialLinesNetwork
 }
+\examples{
+data(routes_fast)
+rnet <- overline(sldf = routes_fast, attrib = "length")
+SLN <- SpatialLinesNetwork(rnet)
+plot(SLN)
+}
 

--- a/man/sum_network_routes.Rd
+++ b/man/sum_network_routes.Rd
@@ -4,7 +4,7 @@
 \alias{sum_network_routes}
 \title{Summarise shortest path between nodes on network}
 \usage{
-sum_network_routes(sln, start, end, sumvars)
+sum_network_routes(sln, start, end, sumvars, combinations = FALSE)
 }
 \arguments{
 \item{sln}{The SpatialLinesNetwork to use.}
@@ -15,6 +15,11 @@ sum_network_routes(sln, start, end, sumvars)
 
 \item{sumvars}{Character vector of variables for which to calculate
 summary statistics.}
+
+\item{combinations}{Boolean value indicating if all combinations of start
+and ends should be calculated. If TRUE then every start Node ID will be routed
+to every end Node ID. This is faster than passing every combination to start
+and end. Default is FALSE.}
 }
 \description{
 Summarise shortest path between nodes on network

--- a/man/sum_network_routes.Rd
+++ b/man/sum_network_routes.Rd
@@ -30,4 +30,14 @@ Find the shortest path on the network between specified nodes and returns
 a SpatialLinesdataFrame containing the path(s) and summary statistics of
 each one.
 }
+\examples{
+data(routes_fast)
+rnet <- overline(sldf = routes_fast, attrib = "length")
+SLN <- SpatialLinesNetwork(rnet)
+weightfield(SLN) # field used to determine shortest path
+shortpath <- sum_network_routes(SLN, 1, 50, sumvars = "length")
+plot(shortpath, col = "red", lwd = 4)
+plot(SLN, add = TRUE)
+
+}
 

--- a/man/summary-SpatialLinesNetwork-method.Rd
+++ b/man/summary-SpatialLinesNetwork-method.Rd
@@ -10,9 +10,15 @@
 \arguments{
 \item{object}{The SpatialLinesNetwork}
 
-\item{...}{Arguments to pass to relevant plot function.}
+\item{...}{Arguments to pass to relevant summary function.}
 }
 \description{
 Print a summary of a SpatialLinesNetwork
+}
+\examples{
+data(routes_fast)
+rnet <- overline(sldf = routes_fast, attrib = "length")
+SLN <- SpatialLinesNetwork(rnet)
+summary(SLN)
 }
 

--- a/man/weightfield.Rd
+++ b/man/weightfield.Rd
@@ -42,4 +42,12 @@ SpatialLinesNetwork. When changing the value of weightfield, the weights
 of the graph network are updated with the values of the corresponding
 variables.
 }
+\examples{
+data(routes_fast)
+rnet <- overline(sldf = routes_fast, attrib = "length")
+SLN <- SpatialLinesNetwork(rnet)
+weightfield(SLN) <- 'length'
+weightfield(SLN, 'randomnum') <- sample(1:10, size = nrow(SLN@sl), replace = TRUE)
+
+}
 


### PR DESCRIPTION
This PR speeds up calculating combinations of routes using a SpatialLinesNetwork. This is useful if you want to calculate all routes from a single origin to many destinations or many origins to the same set of destinations.