### PR TITLE
add stop on useful warnings from google API

### DIFF
--- a/R/google-functions.R
+++ b/R/google-functions.R
@@ -39,9 +39,9 @@ nearest_google <- function(lat, lng, google_api){
 #' @export
 #'
 #' @details
-#' The google API is limited to a maximum of 100 simultaneous queries, and so
-#' will, for example, only returns values for up to 10 origins times 10
-#' destinations.
+#' Absent authorization, the google API is limited to a maximum of 100
+#' simultaneous queries, and so will, for example, only returns values for up to
+#' 10 origins times 10 destinations.
 #'
 #' @examples \dontrun{
 #'  # Distances from one origin to one destination
@@ -94,8 +94,7 @@ dist_google <- function(from, to, google_api = Sys.getenv("GOOGLEDIST"),
   from = paste0(from, collapse = "|")
   to = paste0(to, collapse = "|")
   url_travel <- paste0(base_url, g_units, "&origins=", from,
-          "&destinations=", to,
-          paste0("&mode=", mode))
+                       "&destinations=", to, "&mode=", mode)
   if(class(arrival_time)[1] == "POSIXlt"){
     arrival_time <- as.numeric(arrival_time)
     url_travel <- paste0(url_travel, "&arrival_time=", arrival_time)

--- a/R/google-functions.R
+++ b/R/google-functions.R
@@ -27,13 +27,22 @@ nearest_google <- function(lat, lng, google_api){
 #' @section Details:
 #' Estimate travel times accounting for the road network - see \url{https://developers.google.com/maps/documentation/distance-matrix/}
 #' Note: Currently returns the json object returned by the Google Maps API and uses the same origins and destinations.
-#' @inheritParams route_cyclestreet
+#' @param from Two-column matrix or data frame of coordinates representing
+#' latitude and longitude of origins.
+#' @param to Two-column matrix or data frame of coordinates representing
+#' latitude and longitude of destinations.
 #' @param google_api String value containing the Google API key to use.
 #' @param g_units Text string, either metric (default) or imperial.
 #' @param mode Text string specifying the mode of transport. Can be
 #' bicycling (default), walking, driving or transit
 #' @param arrival_time Time of arrival in date format.
 #' @export
+#'
+#' @details
+#' The google API is limited to a maximum of 100 simultaneous queries, and so
+#' will, for example, only returns values for up to 10 origins times 10
+#' destinations.
+#'
 #' @examples \dontrun{
 #'  # Distances from one origin to one destination
 #'  dist_google(from = c(0, 52), to = c(0, 53))
@@ -97,6 +106,8 @@ dist_google <- function(from, to, google_api = Sys.getenv("GOOGLEDIST"),
   url = utils::URLencode(url, repeated = FALSE, reserved = FALSE)
   message(paste0("Sent this request: ", url))
   obj <- jsonlite::fromJSON(url)
+  if (obj$status != "OK" & any(grepl("error", names(obj))))
+      stop (obj[grepl("error",names(obj))],call.=FALSE)
   # some of cols are data.frames, e.g.
   # lapply(obj$rows$elements[[1]], class)
   # obj$rows$elements[[1]][1]

--- a/man/dist_google.Rd
+++ b/man/dist_google.Rd
@@ -8,13 +8,11 @@ dist_google(from, to, google_api = Sys.getenv("GOOGLEDIST"),
   g_units = "metric", mode = "bicycling", arrival_time = "")
 }
 \arguments{
-\item{from}{Text string or coordinates (a numeric vector of
-\code{length = 2} representing latitude and longitude) representing a point
-on Earth.}
+\item{from}{Two-column matrix or data frame of coordinates representing
+latitude and longitude of origins.}
 
-\item{to}{Text string or coordinates (a numeric vector of
-\code{length = 2} representing latitude and longitude) representing a point
-on Earth. This represents the destination of the trip.}
+\item{to}{Two-column matrix or data frame of coordinates representing
+latitude and longitude of destinations.}
 
 \item{google_api}{String value containing the Google API key to use.}
 
@@ -27,6 +25,11 @@ bicycling (default), walking, driving or transit}
 }
 \description{
 Return travel network distances and time using the Google Maps API
+}
+\details{
+The google API is limited to a maximum of 100 simultaneous queries, and so
+will, for example, only returns values for up to 10 origins times 10
+destinations.
 }
 \section{Details}{
 

--- a/man/dist_google.Rd
+++ b/man/dist_google.Rd
@@ -27,9 +27,9 @@ bicycling (default), walking, driving or transit}
 Return travel network distances and time using the Google Maps API
 }
 \details{
-The google API is limited to a maximum of 100 simultaneous queries, and so
-will, for example, only returns values for up to 10 origins times 10
-destinations.
+Absent authorization, the google API is limited to a maximum of 100
+simultaneous queries, and so will, for example, only returns values for up to
+10 origins times 10 destinations.
 }
 \section{Details}{
 


### PR DESCRIPTION
I trust no code needed here. The former man entries from `route_cyclestreet` described single vectors for `from` and `to`, but these can actually be matrices or data.frames with multiple values. Main problem this solves is the limitation of the google API to 100 queries, so this now prints useful error messages when this limit (or whatever else it might be) is exceeded. The API *should* then always return an `error_message` parameter, but i've gone the safest route of simply using a `grepl` just in case it's not exactly called `error_message`.