### PR TITLE
Got rid of RcppArmadillo "warning" message (which isnt actually a com…

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,0 +1,10 @@
+## Emacs please make this a -*- mode: Makefile; -*-
+##
+## We could set particular variables here. Examples are
+##    PKG_LIBS      for external libraries
+##    PKG_CXXFLAGS  for additional headers or defines
+##    CXX_STD       to select C++11 via 'CXX11'
+## But for standard builds without external dependencies, nothing is needed
+CXX_STD=CXX11
+PKG_CXXFLAGS=-DARMA_DONT_PRINT_OPENMP_WARNING
+PKG_LIBS=


### PR DESCRIPTION
…piler warning)

I think the RcppArmadillo dep can/should be removed completely, the only functionality it seems to use is linspace - which is trivial to implement.