### PR TITLE
Fix #249 by adding do_union = FALSE.

### DIFF
--- a/R/SpatialLinesNetwork.R
+++ b/R/SpatialLinesNetwork.R
@@ -565,7 +565,7 @@ sum_network_routes <- function(sln, start, end, sumvars, combinations = FALSE) {
         crs = sf::st_crs(sln@sl)$epsg
       ) %>%
       dplyr::group_by(.data$linenum) %>%
-      dplyr::summarise() %>%
+      dplyr::summarise(do_union = FALSE) %>%
       sf::st_cast("LINESTRING") %>%
       dplyr::bind_cols(routedata) %>%
       dplyr::select(-.data$linenum)

--- a/R/SpatialLinesNetwork.R
+++ b/R/SpatialLinesNetwork.R
@@ -568,7 +568,7 @@ sum_network_routes <- function(sln, start, end, sumvars, combinations = FALSE) {
       dplyr::summarise(do_union = FALSE) %>%
       sf::st_cast("LINESTRING") %>%
       dplyr::bind_cols(routedata) %>%
-      dplyr::select(-.data$linenum)
+      dplyr::select(-.data$linenum,-.data$do_union)
 
   } else {
 


### PR DESCRIPTION
As @mem48 suggested, needed to add do_union = FALSE to the summarise call to avoid points being reordered based on the X coordinate.