### PR TITLE
update changes to the graphhopper api

### DIFF
--- a/R/routes.R
+++ b/R/routes.R
@@ -281,7 +281,7 @@ route_graphhopper <- function(from, to, l = NULL, vehicle = "bike", silent = TRU
       stop("Invalid API key")
     }
   }
-  route <- sp::SpatialLines(list(sp::Lines(list(sp::Line(obj$paths$points[[1]][[1]][, 1:2])), ID = "1")))
+  route <- sp::SpatialLines(list(sp::Lines(list(sp::Line(obj$paths$points[[2]][[1]][, 1:2])), ID = "1")))
 
   climb <- NA # to set elev variable up
 


### PR DESCRIPTION
I was getting this error: 
Error in obj$paths$points[[1]][[1]][, 1:2] : 
  incorrect number of dimensions

The points were the next line down so changing the first '1' to a '2' fixes this. 