### PR TITLE
Improved error messages

### DIFF
--- a/R/route.R
+++ b/R/route.R
@@ -103,6 +103,7 @@ route_dodgr <-
   if(is.null(net)) {
       pts <- rbind(fm_coords, to_coords)
       net <- dodgr::dodgr_streetnet(pts = pts, expand = 0.2)
+      message("Network not provided, fetching network using dodgr_streetnet")
   }
 
   ckh <- dodgr::dodgr_cache_off()
@@ -133,7 +134,9 @@ route_dodgr <-
   paths <- unlist(paths, recursive = FALSE)
   index <- which (vapply (paths, is.null, logical (1)))
   if (any (index))
-      message ("unable to trace path number ", as.integer (index))
+        message("unable to trace ", length(index), " path(s)")
+        message("Failed path index numbers are:")
+        message(list(as.integer(index)))
   index <- which (!seq (paths) %in% index)
 
   paths <- sf::st_sfc(paths[index], crs = 4326)


### PR DESCRIPTION
I have attempted to improve the error message(s) that are printed when the function cannot route between and origin and destination. The message that is printed where there are more than one path that cannot be routed is a longe string of concatenated index numbers which is confusing, and does not indicate how many failed. It now does.