### PR TITLE
change default url

### DIFF
--- a/R/routes.R
+++ b/R/routes.R
@@ -233,7 +233,7 @@ route_cyclestreet <-
 #' plot(r2, add = TRUE, col = "blue") # compare routes
 #' plot(r3, add = TRUE, col = "red")
 #' }
-route_graphhopper <- function(from, to, l = NULL, vehicle = "bike", silent = TRUE, pat = NULL, base_url = "https://graphhopper.com") {
+route_graphhopper <- function(from, to, l = NULL, vehicle = "bike", silent = TRUE, pat = NULL, base_url = "https://graphhopper.com/api/1") {
 
   # Convert character strings to lon/lat if needs be
   coords <- od_coords(from, to, l)
@@ -244,7 +244,7 @@ route_graphhopper <- function(from, to, l = NULL, vehicle = "bike", silent = TRU
 
   httrmsg <- httr::modify_url(
     base_url,
-    path = "/api/1/route",
+    path = "/route",
     query = list(
       point = paste0(coords[1, c("fy", "fx")], collapse = ","),
       point = paste0(coords[1, c("ty", "tx")], collapse = ","),


### PR DESCRIPTION
the reason to make such change is we can easily build the graphhopper and run it on local. In local, we may not have such path.

For example the default one is localhost:8989/route

without /api/1, making this change will make using local graphhopper much easier

(in fact may people use it on local, otherwise google or osm is better, one big the reason to run graphhopper is it can be deployed in local)