### PR TITLE
Make `overline()` independent of the sf geometry column name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 ## BUG FIXES
 
 - `destination` now works as an argument in `line2route()` (#368)
+- `overline()` now accepts `sf` objects regardless of the name of the geometry column
 
 # stplanr 0.4.1
 

--- a/R/overline.R
+++ b/R/overline.R
@@ -332,7 +332,7 @@ onewaygeo.Spatial <- function(x, attrib) {
 #' plot(rnet1, lwd = lwd)
 #' }
 overline2 = function(x, attrib, ncores = 1, simplify = TRUE, regionalise = 1e5){
-  if(!"sfc_LINESTRING" %in%  class(x$geometry)){
+  if(!"sfc_LINESTRING" %in%  class(sf::st_geometry(x))){
     stop("Only LINESTRING is supported")
   }
   if(any(c("1","2","3","4","grid") %in% attrib)){


### PR DESCRIPTION
The LINESTRING geometry check in `overline2()` does not accept geometry column names other than `"geometry"`:

``` r
library(sf)
#> Linking to GEOS 3.7.2, GDAL 2.4.2, PROJ 5.2.0
library(stplanr)

sf <- st_sf(
  data.frame(
    id = c("l_1", "l_2", "l_3"),
    count = c(1, 1, 1)
  ),
  other_than_geometry = list(
    st_linestring(cbind(c(0,0,1,1,2,2,3,3),c(0,0,1,1,2,2,3,3))),
    st_linestring(cbind(c(0,0,1,1,2,2,3),c(0,0,1,1,2,2,2))),
    st_linestring(cbind(c(0,0,1,1,3),c(0,0,1,1,1)))
  )
)

overline(sf, fun = sum(), attrib = "count")
#> Error in overline2(x = sl, attrib = attrib): Only LINESTRING is supported
```

To make `overline()` independent of the name of the geometry column, access to the geometries by `x$geometry` could be replaced with `sf::st_geometry(x)`.

<details>

<summary>Session info</summary>

``` r
devtools::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value                       
#>  version  R version 3.6.2 (2019-12-12)
#>  os       macOS Catalina 10.15.2      
#>  system   x86_64, darwin15.6.0        
#>  ui       X11                         
#>  language (EN)                        
#>  collate  de_CH.UTF-8                 
#>  ctype    de_CH.UTF-8                 
#>  tz       Europe/Zurich               
#>  date     2020-01-14                  
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version date       lib source        
#>  assertthat    0.2.1   2019-03-21 [1] CRAN (R 3.6.0)
#>  backports     1.1.5   2019-10-02 [1] CRAN (R 3.6.0)
#>  callr         3.4.0   2019-12-09 [1] CRAN (R 3.6.0)
#>  class         7.3-15  2019-01-01 [1] CRAN (R 3.6.2)
#>  classInt      0.4-2   2019-10-17 [1] CRAN (R 3.6.0)
#>  cli           2.0.0   2019-12-09 [1] CRAN (R 3.6.0)
#>  codetools     0.2-16  2018-12-24 [1] CRAN (R 3.6.2)
#>  crayon        1.3.4   2017-09-16 [1] CRAN (R 3.6.0)
#>  curl          4.3     2019-12-02 [1] CRAN (R 3.6.0)
#>  data.table  * 1.12.8  2019-12-09 [1] CRAN (R 3.6.0)
#>  DBI           1.1.0   2019-12-15 [1] CRAN (R 3.6.0)
#>  desc          1.2.0   2018-05-01 [1] CRAN (R 3.6.0)
#>  devtools      2.2.1   2019-09-24 [1] CRAN (R 3.6.0)
#>  digest        0.6.23  2019-11-23 [1] CRAN (R 3.6.0)
#>  dplyr         0.8.3   2019-07-04 [1] CRAN (R 3.6.0)
#>  e1071         1.7-3   2019-11-26 [1] CRAN (R 3.6.0)
#>  ellipsis      0.3.0   2019-09-20 [1] CRAN (R 3.6.0)
#>  evaluate      0.14    2019-05-28 [1] CRAN (R 3.6.0)
#>  fansi         0.4.0   2018-10-05 [1] CRAN (R 3.6.0)
#>  foreign       0.8-74  2019-12-26 [1] CRAN (R 3.6.0)
#>  fs            1.3.1   2019-05-06 [1] CRAN (R 3.6.0)
#>  geosphere     1.5-10  2019-05-26 [1] CRAN (R 3.6.0)
#>  glue          1.3.1   2019-03-12 [1] CRAN (R 3.6.0)
#>  htmltools     0.4.0   2019-10-04 [1] CRAN (R 3.6.0)
#>  igraph        1.2.4.2 2019-11-27 [1] CRAN (R 3.6.0)
#>  KernSmooth    2.23-16 2019-10-15 [1] CRAN (R 3.6.2)
#>  knitr         1.26    2019-11-12 [1] CRAN (R 3.6.0)
#>  lattice       0.20-38 2018-11-04 [1] CRAN (R 3.6.2)
#>  magrittr      1.5     2014-11-22 [1] CRAN (R 3.6.0)
#>  maptools      0.9-9   2019-12-01 [1] CRAN (R 3.6.0)
#>  memoise       1.1.0   2017-04-21 [1] CRAN (R 3.6.0)
#>  openxlsx      4.1.4   2019-12-06 [1] CRAN (R 3.6.0)
#>  pillar        1.4.3   2019-12-20 [1] CRAN (R 3.6.1)
#>  pkgbuild      1.0.6   2019-10-09 [1] CRAN (R 3.6.0)
#>  pkgconfig     2.0.3   2019-09-22 [1] CRAN (R 3.6.0)
#>  pkgload       1.0.2   2018-10-29 [1] CRAN (R 3.6.0)
#>  prettyunits   1.0.2   2015-07-13 [1] CRAN (R 3.6.0)
#>  processx      3.4.1   2019-07-18 [1] CRAN (R 3.6.0)
#>  ps            1.3.0   2018-12-21 [1] CRAN (R 3.6.0)
#>  purrr         0.3.3   2019-10-18 [1] CRAN (R 3.6.0)
#>  R6            2.4.1   2019-11-12 [1] CRAN (R 3.6.0)
#>  raster        3.0-7   2019-09-24 [1] CRAN (R 3.6.0)
#>  Rcpp          1.0.3   2019-11-08 [1] CRAN (R 3.6.0)
#>  remotes       2.1.0   2019-06-24 [1] CRAN (R 3.6.0)
#>  rgeos         0.5-2   2019-10-03 [1] CRAN (R 3.6.0)
#>  rlang         0.4.2   2019-11-23 [1] CRAN (R 3.6.0)
#>  rmarkdown     2.0     2019-12-12 [1] CRAN (R 3.6.0)
#>  rprojroot     1.3-2   2018-01-03 [1] CRAN (R 3.6.0)
#>  sessioninfo   1.1.1   2018-11-05 [1] CRAN (R 3.6.0)
#>  sf          * 0.8-0   2019-09-17 [1] CRAN (R 3.6.0)
#>  sp            1.3-2   2019-11-07 [1] CRAN (R 3.6.0)
#>  stplanr     * 0.4.1   2019-11-23 [1] CRAN (R 3.6.0)
#>  stringi       1.4.3   2019-03-12 [1] CRAN (R 3.6.0)
#>  stringr       1.4.0   2019-02-10 [1] CRAN (R 3.6.0)
#>  testthat      2.3.1   2019-12-01 [1] CRAN (R 3.6.0)
#>  tibble        2.1.3   2019-06-06 [1] CRAN (R 3.6.0)
#>  tidyselect    0.2.5   2018-10-11 [1] CRAN (R 3.6.0)
#>  units         0.6-5   2019-10-08 [1] CRAN (R 3.6.0)
#>  usethis       1.5.1   2019-07-04 [1] CRAN (R 3.6.0)
#>  withr         2.1.2   2018-03-15 [1] CRAN (R 3.6.0)
#>  xfun          0.11    2019-11-12 [1] CRAN (R 3.6.0)
#>  yaml          2.2.0   2018-07-25 [1] CRAN (R 3.6.0)
#>  zip           2.0.4   2019-09-01 [1] CRAN (R 3.6.0)
#> 
#> [1] /Library/Frameworks/R.framework/Versions/3.6/Resources/library
```

</details>