### PR TITLE
Update line2vertices

### DIFF
--- a/R/od-funs.R
+++ b/R/od-funs.R
@@ -379,7 +379,14 @@ line2df.Spatial <- function(l) {
 #' plot(l$geometry)
 #' lpoints2 <- line2pointsn(l)
 #' plot(lpoints2$geometry, add = TRUE)
+#'
+#' # extract only internal vertices
+#' l_internal_vertices <- line2vertices(l)
+#' plot(sf::st_geometry(l), reset = FALSE)
+#' plot(l_internal_vertices, add = TRUE)
+#' # The boundary points are missing
 #' @export
+
 line2points <- function(l, ids = rep(1:nrow(l))) {
   UseMethod("line2points")
 }

--- a/R/od-funs.R
+++ b/R/od-funs.R
@@ -361,9 +361,10 @@ line2df.Spatial <- function(l) {
 #'
 #' The number of points will be double the number of lines with `line2points`. A
 #' closely related function, `line2pointsn` returns all the points that were
-#' line vertices. #' The points corresponding with a given line, `i`, will be
+#' line vertices. The points corresponding with a given line, `i`, will be
 #' `(2*i):((2*i)+1)`. The last function, `line2vertices`, returns all the points
-#' that are vertices but not nodes.
+#' that are vertices but not nodes. If the input `l` object is composed by only
+#' 1 LINESTRING with 2 POINTS, then it returns an empty `sf` object.
 #'
 #' @param l An `sf` object or a `SpatialLinesDataFrame` from the older `sp` package
 #' @param ids Vector of ids (by default `1:nrow(l)`)

--- a/man/line2points.Rd
+++ b/man/line2points.Rd
@@ -20,9 +20,10 @@ line2vertices(l)
 \description{
 The number of points will be double the number of lines with \code{line2points}. A
 closely related function, \code{line2pointsn} returns all the points that were
-line vertices. #' The points corresponding with a given line, \code{i}, will be
+line vertices. The points corresponding with a given line, \code{i}, will be
 \code{(2*i):((2*i)+1)}. The last function, \code{line2vertices}, returns all the points
-that are vertices but not nodes.
+that are vertices but not nodes. If the input \code{l} object is composed by only
+1 LINESTRING with 2 POINTS, then it returns an empty \code{sf} object.
 }
 \examples{
 l <- routes_fast_sf[2, ]

--- a/man/line2points.Rd
+++ b/man/line2points.Rd
@@ -34,6 +34,12 @@ plot(lpoints, add = TRUE)
 plot(l$geometry)
 lpoints2 <- line2pointsn(l)
 plot(lpoints2$geometry, add = TRUE)
+
+# extract only internal vertices
+l_internal_vertices <- line2vertices(l)
+plot(sf::st_geometry(l), reset = FALSE)
+plot(l_internal_vertices, add = TRUE)
+# The boundary points are missing
 }
 \seealso{
 Other lines: 


### PR DESCRIPTION
``` r
# upgrade packages
remotes::install_github("agila5/stplanr", ref = "update_line2vertices")
#> Skipping install of 'stplanr' from a github remote, the SHA1 (f48b17b3) has not changed since last install.
#>   Use `force = TRUE` to force installation

# packages
library(sf)
#> Linking to GEOS 3.7.1, GDAL 2.2.2, PROJ 4.9.2
library(stplanr)

# fake data
my_fake_linestring <- st_sf(
  data.frame(x = c(1, 2)), 
  geometry = st_sfc(
    st_linestring(rbind(c(0, 0), c(1, 0), c(2, 0))), 
    st_linestring(rbind(c(1, 0), c(1, 1)))
  )
)
line2vertices(my_fake_linestring)
#> Simple feature collection with 1 feature and 1 field
#> geometry type:  POINT
#> dimension:      XY
#> bbox:           xmin: 1 ymin: 0 xmax: 1 ymax: 0
#> CRS:            NA
#>   L1    geometry
#> 1  1 POINT (1 0)
```

<sup>Created on 2020-10-05 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>