### PR TITLE
Fix network routing with identical nodes

### DIFF
--- a/R/SpatialLinesNetwork.R
+++ b/R/SpatialLinesNetwork.R
@@ -501,47 +501,55 @@ find_network_nodes <- function(sln, x, y = NULL, maxdist = 1000) {
 #' Summarise shortest path between nodes on network
 #'
 #' @section Details:
-#' Find the shortest path on the network between specified nodes and returns
-#' a SpatialLinesdataFrame containing the path(s) and summary statistics of
-#' each one.
+#' Find the shortest path on the network between specified nodes and returns a
+#' `SpatialLinesDataFrame` (or an `sf` object with LINESTRING geometry)
+#' containing the path(s) and summary statistics of each one.
 #'
 #' The start and end arguments must be integers representing the node index.
-#' To find which node is closes to a geographic point, use `find_nearest_node()`
+#' To find which node is closest to a geographic point, use `find_nearest_node()`.
 #'
-#' @param sln The SpatialLinesNetwork to use.
-#' @param start Integer of node indices where route ends.
+#' If the start and end node are identical, the function will return a
+#' degenerate line with just two (identical) points. See
+#' [#444](https://github.com/ropensci/stplanr/issues/444).
+#'
+#' @param sln The SpatialLinesNetwork or sfNetwork to use.
+#' @param start Integer of node indices where route starts.
 #' @param end Integer of node indices where route ends.
 #' @param sumvars Character vector of variables for which to calculate
 #' summary statistics. The default value is `weightfield(sln)`.
 #' @param combinations Boolean value indicating if all combinations of start
 #' and ends should be calculated. If TRUE then every start Node ID will be routed
 #' to every end Node ID. This is faster than passing every combination to start
-#' and end. Default is FALSE.
+#' and end. Default is `FALSE`.
 #' @family rnet
 #'
 #' @examples
-#' # tests fail on dev version of dplyr
 #' sln <- SpatialLinesNetwork(route_network)
 #' weightfield(sln) # field used to determine shortest path
 #' shortpath <- sum_network_routes(sln, start = 1, end = 50, sumvars = "length")
 #' plot(shortpath, col = "red", lwd = 4)
 #' plot(sln, add = TRUE)
+#'
 #' # with sf objects
 #' sln <- SpatialLinesNetwork(route_network_sf)
 #' weightfield(sln) # field used to determine shortest path
 #' shortpath <- sum_network_routes(sln, start = 1, end = 50, sumvars = "length")
 #' plot(sf::st_geometry(shortpath), col = "red", lwd = 4)
 #' plot(sln, add = TRUE)
+#'
 #' # find shortest path between two coordinates
 #' sf::st_bbox(sln@sl)
 #' start_coords <- c(-1.546, 53.826)
 #' end_coords <- c(-1.519, 53.816)
 #' plot(sln)
-#' plot(sf::st_point(start_coords), cex = 3, add = TRUE)
-#' plot(sf::st_point(end_coords), cex = 3, add = TRUE)
+#' plot(sf::st_point(start_coords), cex = 3, add = TRUE, col = "red")
+#' plot(sf::st_point(end_coords), cex = 3, add = TRUE, col = "blue")
 #' nodes <- find_network_nodes(sln, rbind(start_coords, end_coords))
 #' shortpath <- sum_network_routes(sln, nodes[1], nodes[2])
-#' plot(sf::st_geometry(shortpath), col = "red", lwd = 3, add = TRUE)
+#' plot(sf::st_geometry(shortpath), col = "darkred", lwd = 3, add = TRUE)
+#'
+#' # degenerate path
+#' sum_network_routes(sln, start = 1, end = 1)
 #' @export
 sum_network_routes <- function(sln, start, end, sumvars = weightfield(sln), combinations = FALSE) {
   if (!is(sln, "SpatialLinesNetwork") & !is(sln, "sfNetwork")) {

--- a/man/route_local.Rd
+++ b/man/route_local.Rd
@@ -7,7 +7,7 @@
 route_local(sln, from, to, l = NULL)
 }
 \arguments{
-\item{sln}{The SpatialLinesNetwork to use.}
+\item{sln}{The SpatialLinesNetwork or sfNetwork to use.}
 
 \item{from}{An object representing origins
 (if lines are provided as the first argument, from is assigned to \code{l})}

--- a/man/sln2points.Rd
+++ b/man/sln2points.Rd
@@ -8,7 +8,7 @@ or sfNetwork.}
 sln2points(sln)
 }
 \arguments{
-\item{sln}{The SpatialLinesNetwork to use.}
+\item{sln}{The SpatialLinesNetwork or sfNetwork to use.}
 }
 \description{
 Generate spatial points representing nodes on a SpatialLinesNetwork

--- a/man/sum_network_routes.Rd
+++ b/man/sum_network_routes.Rd
@@ -13,9 +13,9 @@ sum_network_routes(
 )
 }
 \arguments{
-\item{sln}{The SpatialLinesNetwork to use.}
+\item{sln}{The SpatialLinesNetwork or sfNetwork to use.}
 
-\item{start}{Integer of node indices where route ends.}
+\item{start}{Integer of node indices where route starts.}
 
 \item{end}{Integer of node indices where route ends.}
 
@@ -25,44 +25,52 @@ summary statistics. The default value is \code{weightfield(sln)}.}
 \item{combinations}{Boolean value indicating if all combinations of start
 and ends should be calculated. If TRUE then every start Node ID will be routed
 to every end Node ID. This is faster than passing every combination to start
-and end. Default is FALSE.}
+and end. Default is \code{FALSE}.}
 }
 \description{
 Summarise shortest path between nodes on network
 }
 \section{Details}{
 
-Find the shortest path on the network between specified nodes and returns
-a SpatialLinesdataFrame containing the path(s) and summary statistics of
-each one.
+Find the shortest path on the network between specified nodes and returns a
+\code{SpatialLinesDataFrame} (or an \code{sf} object with LINESTRING geometry)
+containing the path(s) and summary statistics of each one.
 
 The start and end arguments must be integers representing the node index.
-To find which node is closes to a geographic point, use \code{find_nearest_node()}
+To find which node is closest to a geographic point, use \code{find_nearest_node()}.
+
+If the start and end node are identical, the function will return a
+degenerate line with just two (identical) points. See
+\href{https://github.com/ropensci/stplanr/issues/444}{#444}.
 }
 
 \examples{
-# tests fail on dev version of dplyr
 sln <- SpatialLinesNetwork(route_network)
 weightfield(sln) # field used to determine shortest path
 shortpath <- sum_network_routes(sln, start = 1, end = 50, sumvars = "length")
 plot(shortpath, col = "red", lwd = 4)
 plot(sln, add = TRUE)
+
 # with sf objects
 sln <- SpatialLinesNetwork(route_network_sf)
 weightfield(sln) # field used to determine shortest path
 shortpath <- sum_network_routes(sln, start = 1, end = 50, sumvars = "length")
 plot(sf::st_geometry(shortpath), col = "red", lwd = 4)
 plot(sln, add = TRUE)
+
 # find shortest path between two coordinates
 sf::st_bbox(sln@sl)
 start_coords <- c(-1.546, 53.826)
 end_coords <- c(-1.519, 53.816)
 plot(sln)
-plot(sf::st_point(start_coords), cex = 3, add = TRUE)
-plot(sf::st_point(end_coords), cex = 3, add = TRUE)
+plot(sf::st_point(start_coords), cex = 3, add = TRUE, col = "red")
+plot(sf::st_point(end_coords), cex = 3, add = TRUE, col = "blue")
 nodes <- find_network_nodes(sln, rbind(start_coords, end_coords))
 shortpath <- sum_network_routes(sln, nodes[1], nodes[2])
-plot(sf::st_geometry(shortpath), col = "red", lwd = 3, add = TRUE)
+plot(sf::st_geometry(shortpath), col = "darkred", lwd = 3, add = TRUE)
+
+# degenerate path
+sum_network_routes(sln, start = 1, end = 1)
 }
 \seealso{
 Other rnet: 


### PR DESCRIPTION
Reprex of the current results: 

``` r
# update packages
remotes::install_github("ropensci/stplanr", ref = "c0e1e9c1f18e4f94f64fe4e81e2b6c0e4b4720c4")
#> Using github PAT from envvar GITHUB_PAT
#> Skipping install of 'stplanr' from a github remote, the SHA1 (c0e1e9c1) has not changed since last install.
#>   Use `force = TRUE` to force installation

# load packages
library(stplanr)
library(sf)
#> Linking to GEOS 3.8.0, GDAL 3.0.4, PROJ 6.3.1

# create object
sln_sf <- SpatialLinesNetwork(route_network_sf)

# tests
sum_network_routes(sln_sf, start = c(1, 2), end = c(2, 3)) # regular
#> Simple feature collection with 2 features and 3 fields
#> geometry type:  LINESTRING
#> dimension:      XY
#> bbox:           xmin: -1.550964 ymin: 53.82387 xmax: -1.546613 ymax: 53.82496
#> geographic CRS: WGS 84
#> # A tibble: 2 x 4
#>                                              geometry    ID sum_length pathfound
#>                                      <LINESTRING [°]> <dbl>      <dbl> <lgl>    
#> 1 (-1.550139 53.82495, -1.549882 53.8244, -1.549642 ~     1       217. TRUE     
#> 2 (-1.550964 53.82408, -1.549629 53.82387, -1.549642~     2       449. TRUE
sum_network_routes(sln_sf, start = 1, end = 1) # invalid
#> Simple feature collection with 1 feature and 3 fields
#> geometry type:  LINESTRING
#> dimension:      XY
#> bbox:           xmin: -1.550139 ymin: 53.82495 xmax: -1.550139 ymax: 53.82495
#> geographic CRS: WGS 84
#>   ID sum_length pathfound                       geometry
#> 1  1         NA     FALSE LINESTRING (-1.550139 53.82...
sum_network_routes(sln_sf, start = c(1, 2), end = c(1, 2)) # invalid
#> Simple feature collection with 2 features and 3 fields
#> geometry type:  LINESTRING
#> dimension:      XY
#> bbox:           xmin: -1.550964 ymin: 53.82408 xmax: -1.550139 ymax: 53.82495
#> geographic CRS: WGS 84
#>   ID sum_length pathfound                       geometry
#> 1  1         NA     FALSE LINESTRING (-1.550139 53.82...
#> 2  1         NA     FALSE LINESTRING (-1.550964 53.82...
# the following doesn't work since it mixes valid and invalid nodes
sum_network_routes(sln_sf, start = c(1, 2), end = c(1, 20))
#> Error in linecoords[, "L1"]: attributo 'dimnames' mancante per l'array
```

<sup>Created on 2020-11-26 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Hi @jmlondon, could you check if this approach works also in your example? In that case, I will document these ideas and add something for the last scenario. 