### PR TITLE
Switch parts of overline to data.table

### DIFF
--- a/R/overline.R
+++ b/R/overline.R
@@ -232,12 +232,8 @@ overline2 <-
     sl <- cbind(c3, sl)
     rm(c3)
 
-    # browser()
-    # if(requireNamespace("data.table", quietly = TRUE)) {
-    #   sl = data.table::data.table(sl)
-    # }
-    slg <- dplyr::group_by_at(sl, c("1", "2", "3", "4"))
-    sls <- dplyr::ungroup(dplyr::summarise_all(slg, .funs = fun))
+    sls <- dplyr::group_by_at(sl, c("1", "2", "3", "4"))
+    sls <- dplyr::ungroup(dplyr::summarise_all(sls, .funs = fun))
     attrib <- names(sls)[5:ncol(sls)]
     coords <- as.matrix(sls[, 1:4])
     sl <- sls[, -c(1:4)]
@@ -300,13 +296,11 @@ overline2 <-
           })
           overlined_simple <- if (requireNamespace("pbapply", quietly = TRUE)) {
             pbapply::pblapply(sl, function(y) {
-              y <- dplyr::group_by_at(y, attrib)
-              y <- dplyr::summarise(y, do_union = FALSE, .groups = "drop")
+              ol_grp(y, attrib)
             }, cl = cl)
           } else {
             lapply(sl, function(y) {
-              y <- dplyr::group_by_at(y, attrib)
-              y <- dplyr::summarise(y, do_union = FALSE, .groups = "drop")
+              ol_grp(y, attrib)
             })
           }
 
@@ -315,13 +309,11 @@ overline2 <-
         } else {
           overlined_simple <- if (requireNamespace("pbapply", quietly = TRUE)) {
             pbapply::pblapply(sl, function(y) {
-              y <- dplyr::group_by_at(y, attrib)
-              y <- dplyr::summarise(y, do_union = FALSE, .groups = "drop")
+              ol_grp(y, attrib)
             })
           } else {
             lapply(sl, function(y) {
-              y <- dplyr::group_by_at(y, attrib)
-              y <- dplyr::summarise(y, do_union = FALSE, .groups = "drop")
+              ol_grp(y, attrib)
             })
           }
         }
@@ -333,8 +325,8 @@ overline2 <-
         if (!quiet) {
           message(paste0(Sys.time(), " aggregating flows"))
         }
-        overlined_simple <- dplyr::group_by_at(sl, attrib)
-        overlined_simple <- dplyr::summarise(overlined_simple, do_union = FALSE, .groups = "drop")
+
+        overlined_simple <- ol_grp(sl, attrib)
         rm(sl)
       }
 
@@ -363,6 +355,11 @@ overline2 <-
 #' @export
 overline.sf <- overline2
 
+ol_grp <- function(sl, attrib){
+  sl <- data.table::data.table(sl)
+  sl <- sl[, .(geometry = st_combine(geometry)), by = attrib]
+  sf::st_as_sf(sl)
+}
 
 #' Aggregate flows so they become non-directional (by geometry - the slow way)
 #'


### PR DESCRIPTION
@Robinlovelace a very quick look at speeding up overline2. I've replaced some `dplyr` code with `data.table`

```
bench::mark(t1 = stplanr::overline2(r, c("bicycle","car_driver","all")),
            t2 = overline2(r, attrib = c("bicycle","car_driver","all")),
            check = FALSE)

# A tibble: 2 × 13
  expression    min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result
  <bch:expr> <bch:> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>
1 t1          45.3s  45.3s    0.0221   13.46GB    0.728     1    33      45.3s <NULL>
2 t2          24.6s  24.6s    0.0406    2.06GB    1.50      1    37      24.6s <NULL>

t1 <- t1[order(t1$bicycle, t1$all),]
t2 <- t2[order(t2$bicycle, t2$all),]
identical(t1, t2) # TRUE
```

Resutls come out in a different order, but I don't think that matters. I've not tested all use cases like large data and use multicore.

Its a modest speed inmprovements but a major reduction in memory usage which should help.

There is another bit of `dplyr` code I can't work out how to do in `data.table`

```
sls <- dplyr::group_by_at(sl, c("1", "2", "3", "4"))
sls <- dplyr::ungroup(dplyr::summarise_all(sls, .funs = fun))
```

but the fix I have made is to only make one object `sls` rather than making an `slg` object that is never used again.
