### PR TITLE
refactor mats2line() for speed enhancement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,8 @@ Imports:
     Rcpp (>= 0.12.1),
     rlang (>= 0.2.2),
     sf (>= 0.6.3),
-    sfheaders
+    sfheaders,
+    vctrs (>= 0.4.0)
 Suggests:
     cyclestreets,
     dodgr (>= 0.2.15),

--- a/tests/testthat/test-mats2line.R
+++ b/tests/testthat/test-mats2line.R
@@ -1,0 +1,20 @@
+test_that("mats2line() constructs linestrings correctly", {
+  m1 <- matrix(c(1, 2, 1, 2), ncol = 2)
+  m2 <- matrix(c(9, 9, 9, 1), ncol = 2)
+  l <- mats2line(m1, m2)
+
+  # we expect an sfc_LINESTRING
+  expect_s3_class(l, c("sfc", "sfc_LINESTRING"))
+
+  # default CRS should be NA
+  expect_equal(sf::st_crs(l), sf::st_crs(NA))
+
+  # construct the same sfc_LINESTRING by hand
+  l2 <- sf::st_sfc(
+    sf::st_linestring(matrix(c(1, 9, 1, 9), ncol = 2)),
+    sf::st_linestring(matrix(c(2, 9, 2, 1), ncol = 2))
+  )
+
+  # test that they are identical
+  expect_identical(l, l2)
+})


### PR DESCRIPTION
This PR closes #539. 

It refactors `mats2line()` by utilizing `vec_interleave()` and `sfheaders::sfc_linestring()`. It adds an explicit dependency on vctrs (minimum version 0.4.0 as that is when vec_interleave() was added). 

> Note that vctrs is implicitly imported at present, this just makes it explicit. 

An additional test is added to verify the validity of the linestrings that are created by `mats2line()`.
Checks are additionally added to verify that `mat1` and `mat2` are of compatible sizes. 